### PR TITLE
Fix claim, make it essential and collapse request object

### DIFF
--- a/draft-authors-datarightplus-sharing-arrangement-v2.md
+++ b/draft-authors-datarightplus-sharing-arrangement-v2.md
@@ -80,15 +80,10 @@ In addition to the provisions outlined in [@!DATARIGHTPLUS-INFOSEC-BASELINE] the
 
 1. **SHALL** support the `dio:sharing` authorisation scope;
 2. **SHALL** include the `dio:sharing` authorisation scope within Dynamic Client Registration responses;
+3. **SHALL** support request objects containing an essential ID Token claim named `urn:dio:action_id` referencing a valid _Action Identifier_;
+2. **SHALL** reject request objects containing a `urn:dio:action_id` claim that is unknown, expired or not associated with the requesting Initiator;
 
-### Request Object
-
-The request object submitted to the authorisation server:
-
-1. **SHALL** require an ID Token claim `urn:dio:action_id` referencing a valid _Action Identifier_;
-2. **SHALL** reject requests containing a `urn:dio:action_id` claim that is unknown, expired or not associated with the requesting Initiator;
-
-#### Example
+### Example
 
 The following is a non-normative example of a decoded request object requesting authorisation for a previously lodged `actionId`
 
@@ -105,7 +100,10 @@ The following is a non-normative example of a decoded request object requesting 
   "scope": "openid",
   "claims": {
     "id_token": {
-       "urn:dio:action_id": "496a3ba7-04b4-4362-b775-9e0433e48eea",
+       "urn:dio:action_id": {
+          "essential": true,
+          "values": ["496a3ba7-04b4-4362-b775-9e0433e48eea"]
+       },
       "acr": {
         "essential": true,
         "values": ["urn:cds.au:cdr:3"]


### PR DESCRIPTION
This fixes the action_id claim example, ensures it is declared as an essential and collapses the request object definition into authorisation server provisions.

Closes #4 
Depends on https://github.com/datarightplus/datarightplus-redocly/pull/19